### PR TITLE
Add support for nil auth

### DIFF
--- a/smtpurl.go
+++ b/smtpurl.go
@@ -48,13 +48,12 @@ func Parse(raw string) (string, smtp.Auth, error) {
 		default:
 			return "", nil, fmt.Errorf("unsupported auth method: %s", strings.ToUpper(su[1]))
 		}
-	} else {
-		if u.User == nil {
-			return host, auth, nil
-		}
+	} else if u.User != nil{
 		// PLAIN
 		pass, _ := u.User.Password()
 		auth = smtp.PlainAuth("", u.User.Username(), pass, hostname)
+	} else {
+		return host, auth, nil
 	}
 	return host, auth, nil
 }

--- a/smtpurl.go
+++ b/smtpurl.go
@@ -49,6 +49,9 @@ func Parse(raw string) (string, smtp.Auth, error) {
 			return "", nil, fmt.Errorf("unsupported auth method: %s", strings.ToUpper(su[1]))
 		}
 	} else {
+		if u.User == nil {
+			return host, auth, nil
+		}
 		// PLAIN
 		pass, _ := u.User.Password()
 		auth = smtp.PlainAuth("", u.User.Username(), pass, hostname)

--- a/smtpurl_test.go
+++ b/smtpurl_test.go
@@ -42,6 +42,11 @@ func TestParse(t *testing.T) {
 			"smtp.example.com:25",
 			smtp.CRAMMD5Auth("username", "password"),
 			false,
+		},{
+			"smtp://smtp.example.com",
+			"smtp.example.com:25",
+			nil,
+			false,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
When neither the user nor the auth method is provided, auth will be interpreted as nil.